### PR TITLE
Missing dependencies 

### DIFF
--- a/deepsea-install.sh
+++ b/deepsea-install.sh
@@ -14,7 +14,7 @@ sudo zypper --non-interactive --no-gpg-checks removerepo devel_languages_python
 #--- can be dropped once python-click reaches SES5 channel
 #---------------------------------------------------------
 
-sudo zypper --non-interactive --no-gpg-checks install --no-recommends make rpm
+sudo zypper --non-interactive --no-gpg-checks install --no-recommends make rpm git-core
 test -d DeepSea || git clone --depth 1 --branch susecon2017 https://github.com/smithfarm/DeepSea.git
 cd DeepSea
 ls -l

--- a/deepsea-salt-minion.sls
+++ b/deepsea-salt-minion.sls
@@ -7,6 +7,7 @@ salt:
   pkg.installed:
     - pkgs:
       - salt-minion
+      - cron
 
 switch-master:
   cmd.script:


### PR DESCRIPTION
Added git-core as a dependence to the deepsea-install.sh - otherwise you couldn't clone the DeepSea repo

Added cron as a dependence - otherwise prometheus cron creation will fail during stage.3